### PR TITLE
Add Linux AArch64 wheel build support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,60 @@ jobs:
           root: /dimod/dist/
           paths: .
 
+  build-manylinux-aarch64:
+
+    parameters:
+      manylinux-tag:
+        type: string
+      manylinux-arch:
+        type: string
+      python-version:
+        type: string
+
+    machine:
+      image: ubuntu-2004:202101-01
+
+    resource_class: arm.medium
+
+    steps:
+      - checkout
+
+      - run:
+          name: Fix git checkout
+          command: git reset --hard
+
+      - run:
+          name: Build wheels
+          command: |
+            pyv=<< parameters.python-version >>
+            pyv="${pyv//.}"
+            pyv="${pyv:0:2}"
+            docker run -e pyv=$pyv --rm -v $PWD:/ws:rw --workdir=/ws \
+            quay.io/pypa/<< parameters.manylinux-tag >>_<< parameters.manylinux-arch >> \
+            bash -exc '
+              for py in /opt/python/cp*${pyv}*/bin/python;
+              do
+                  $py -m pip wheel . -w ./wheelhouse --no-deps;
+              done
+            '
+      - run:
+          name: bundle shared libraries into wheels
+          command: |
+            docker run -e pyv=$pyv --rm -v $PWD:/ws:rw --workdir=/ws \
+            quay.io/pypa/<< parameters.manylinux-tag >>_<< parameters.manylinux-arch >> \
+            bash -exc '
+              for whl in ./wheelhouse/dimod*.whl; do
+                auditwheel repair "$whl" -w ./dist
+              done
+            '
+
+      - store_artifacts:
+          path: ./dist
+
+      - persist_to_workspace:
+          root: ./dist/
+          paths: .
+
   build-sdist:
     docker:
       - image: circleci/python:3.9-buster
@@ -135,6 +189,71 @@ jobs:
             . env/bin/activate
             cd tests/
             codecov
+
+  test-linux-aarch64:
+    parameters:
+      manylinux-tag:
+        type: string
+      manylinux-arch:
+        type: string
+      python-version:
+        type: string
+      numpy-version:
+        type: string
+
+    machine:
+      image: ubuntu-2004:202101-01
+
+    resource_class: arm.medium
+
+    steps:
+      - checkout
+
+      - attach_workspace:
+          at: dist
+
+      # Make sure that we're using the built dimod and not one from pypi
+      - run:
+          name: install
+          command: |
+            npv='<< parameters.numpy-version >>'
+            pyv='<< parameters.python-version >>'
+            docker run -e npv=$npv -e pyv=$pyv --rm -v $PWD:/ws:rw --workdir=/ws \
+            quay.io/pypa/<< parameters.manylinux-tag >>_<< parameters.manylinux-arch >> \
+            bash -exc '
+              /opt/python/${pyv}/bin/python -m venv env
+              . env/bin/activate
+              pip install -U pip setuptools wheel
+              pip install -U pip pyparsing
+              pip install -r tests/requirements.txt
+              pip install dimod==0.10.4
+              pip install Cython>=0.29.21
+              pip install numpy${npv} --upgrade --only-binary=numpy
+              pip install dwave-preprocessing --no-build-isolation
+              pip install dimod --no-index -f dist/ --no-deps --force-reinstall
+            '
+
+      - run:
+          name: run tests
+          command: |
+            docker run --rm -v $PWD:/ws:rw --workdir=/ws \
+            quay.io/pypa/<< parameters.manylinux-tag >>_<< parameters.manylinux-arch >> \
+            bash -exc '
+              . env/bin/activate
+              cd tests/
+              coverage run --source=dimod --append -m unittest
+            '
+
+      - run:
+          name: codecov
+          command: |
+            docker run --rm -v $PWD:/ws:rw --workdir=/ws \
+            quay.io/pypa/<< parameters.manylinux-tag >>_<< parameters.manylinux-arch >> \
+            bash -exc '
+              . env/bin/activate
+              cd tests/
+              codecov
+            '
 
   deploy-linux:
     docker:
@@ -453,6 +572,28 @@ workflows:
                 python-version: 3.9.4
               - numpy-version: ==1.17.3
                 python-version: 3.9.4
+      - build-manylinux-aarch64:
+          name: build-<< matrix.manylinux-tag >>_<< matrix.manylinux-arch >>-py<< matrix.python-version >>
+          matrix:
+            parameters:
+              python-version: &python-versions [3.6.14, 3.7.11, 3.8.11, 3.9.6]
+              manylinux-tag: &manylinux-tags ["manylinux2014"]
+              manylinux-arch: &manylinux-archs ["aarch64"]
+      - test-linux-aarch64:
+          name: test-linux-<< matrix.manylinux-arch >>-numpy<< matrix.numpy-version >>-py<< matrix.python-version >>
+          # We could break each of these out into seperate jobs so that we
+          # don't need to wait for the entire above matrix to complete, but
+          # this is cleaner
+          requires:
+            - build-manylinux-aarch64
+          matrix:
+            parameters:
+              # test the lowest numpy version and the highest minor of each
+              # currently deployed
+              numpy-version: [<1.20, <1.21]
+              python-version: ["cp37-cp37m", "cp38-cp38", "cp39-cp39"]
+              manylinux-tag: *manylinux-tags
+              manylinux-arch: *manylinux-archs
       - test-osx:
           matrix:
             parameters:
@@ -483,6 +624,18 @@ workflows:
               python-version: *python-versions
               manylinux-tag: *manylinux-tags
               manylinux-arch: *manylinux-archs
+      - build-manylinux-aarch64:
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+)*((\.dev|rc)([0-9]+)?)?$/
+            branches:
+              ignore: /.*/
+          name: build-<< matrix.manylinux-tag >>_<< matrix.manylinux-arch >>-py<< matrix.python-version >>
+          matrix:
+            parameters:
+              python-version: *python-versions
+              manylinux-tag: *manylinux-tags
+              manylinux-arch: *manylinux-archs
       - build-sdist:
           filters:
             tags:
@@ -496,6 +649,7 @@ workflows:
             branches:
               ignore: /.*/
           requires:
+            - build-manylinux-aarch64
             - build-manylinux
             - build-sdist
       - deploy-osx:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,6 +3,6 @@ codecov
 
 parameterized==0.7.4
 
-pandas==0.25.3; python_version < '3.9'
+pandas==1.1.4; python_version < '3.9'
 networkx==2.5
 pymongo==3.7.1; python_version < '3.9'


### PR DESCRIPTION
Owner: Madhukar
Fix: Add support to deploy Linux AArch64 wheels
Build logs: https://app.circleci.com/pipelines/github/odidev/dimod
Reviewer: Pruthvi and Disha

Note: Failure is not related to this PR.
